### PR TITLE
Made off-by-one adjustments for specials tokens

### DIFF
--- a/lda2vec/corpus.py
+++ b/lda2vec/corpus.py
@@ -96,6 +96,7 @@ class Corpus():
         """ Get the loose keys in order of decreasing frequency"""
         loose_counts = sorted(self.counts_loose.items(), key=lambda x: x[1],
                               reverse=True)
+        loose_counts = [i for i in loose_counts if i[0] not in self.specials.values()]
         keys = np.array(loose_counts)[:, 0]
         counts = np.array(loose_counts)[:, 1]
         order = np.argsort(counts)[::-1].astype('int32')
@@ -415,7 +416,7 @@ class Corpus():
         self._check_finalized()
         n_docs = word_compact.shape[0]
         max_length = word_compact.shape[1]
-        idx = word_compact > self.n_specials
+        idx = word_compact >= self.n_specials
         components_raveled = []
         msg = "Length of each component must much `word_compact` size"
         for component in components:
@@ -552,7 +553,7 @@ class Corpus():
         rep1 = lambda w: w.replace(' ', '_')
         rep2 = lambda w: w.title().replace(' ', '_')
         reps = [rep0, rep1, rep2]
-        for compact in np.arange(top):
+        for compact in np.arange(min(top, n_words)):
             loose = self.compact_to_loose.get(compact, None)
             if loose is None:
                 continue


### PR DESCRIPTION
`preprocess.tokenize()` pads texts with -2 (the SKIP index), which puts it in the corpus vocabulary and `counts_loose`.

`_loose_keys_ordered()` then prepends the specials tokens (OOV and SKIP) while making `keys_loose`, thus allocating two array entries to SKIP (instead of 1 as desired, I assume). 

This becomes a problem when you try to train a model using all of the words in the vocabulary, and in lda2vec_run.py,

`model.sampler.W.data[:, :] = vectors[:n_vocab, :]`

W is created with one more row than there are unique words + specials, since `n_keys` is derived from the concatenated array length created in `_loose_keys_ordered()`,  and not the unique number of words in the vocabulary as created by `counts_loose`
