### PR TITLE
FIX: Import path in `lda2vec/__init__.py`

### DIFF
--- a/lda2vec/__init__.py
+++ b/lda2vec/__init__.py
@@ -1,17 +1,7 @@
-import dirichlet_likelihood
-import embed_mixture
-import tracking
-import preprocess
-import corpus
-import topics
-import negative_sampling
-
-dirichlet_likelihood = dirichlet_likelihood.dirichlet_likelihood
-EmbedMixture = embed_mixture.EmbedMixture
-Tracking = tracking.Tracking
-tokenize = preprocess.tokenize
-Corpus = corpus.Corpus
-prepare_topics = topics.prepare_topics
-print_top_words_per_topic = topics.print_top_words_per_topic
-negative_sampling = negative_sampling.negative_sampling
-topic_coherence = topics.topic_coherence
+from .dirichlet_likelihood import dirichlet_likelihood
+from .embed_mixture import EmbedMixture
+from .tracking import Tracking
+from .preprocess import tokenize
+from .corpus import Corpus
+from .topics import prepare_topics, print_top_words_per_topic, topic_coherence
+from .negative_sampling import negative_sampling


### PR DESCRIPTION
This commit allows to import `lda2vec` as a package, regardless of where it's called from.
