### PR TITLE
renamed fn from newer version of pyxDamerauLevenshtein

### DIFF
--- a/lda2vec/corpus.py
+++ b/lda2vec/corpus.py
@@ -4,7 +4,7 @@ import difflib
 import pandas as pd
 
 try:
-    from pyxdameraulevenshtein import damerau_levenshtein_distance_withNPArray
+    from pyxdameraulevenshtein import damerau_levenshtein_distance_ndarray 
 except ImportError:
     pass
 
@@ -572,7 +572,7 @@ class Corpus():
                     idx = lengths >= len(word) - 3
                     idx &= lengths <= len(word) + 3
                     sel = choices[idx]
-                    d = damerau_levenshtein_distance_withNPArray(word, sel)
+                    d = damerau_levenshtein_distance_ndarray(word, sel)
                     choice = np.array(keys_raw)[idx][np.argmin(d)]
                     # choice = difflib.get_close_matches(word, choices)[0]
                     vector = model[choice]


### PR DESCRIPTION
I had to install a few things that weren't mentioned in the requirements.
- pyxDamerauLevenshtein
- gensim
- h5py

For the first lib, the API seems to have changed somewhat since this was run (see https://github.com/gfairchild/pyxDamerauLevenshtein/blob/f657916e4b0db18935c9e32f7dd3c98df95bc15a/CHANGES.md#L5).  This PR fixes that.
