### PR TITLE
Update pyLDAvis installation instruction in lda2vec twenty_newsgroups exmaple.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@
 
 language: python
 
-env:
-    global:
-        - NUMPY_VERSION=1.10
-
 matrix:
     include:
         # All the versions of Python.
@@ -19,7 +15,7 @@ before_install:
 install:
     - conda create --yes -n testing python=$TRAVIS_PYTHON_VERSION
     - source activate testing
-    - conda install --yes numpy=$NUMPY_VERSION nose pip numba cython scikit-learn h5py
+    - conda install --yes numpy nose pip numba cython scikit-learn h5py libgfortran
     - pip install chainer pytest spacy codecov coveralls  pytest-cov
     - python -m spacy.en.download --force all
     - python setup.py install

--- a/examples/twenty_newsgroups/lda2vec/lda2vec.ipynb
+++ b/examples/twenty_newsgroups/lda2vec/lda2vec.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "You must be using a very recent version of pyLDAvis to use the lda2vec outputs. \n",
     "As of this writing, anything past Jan 6 2016 or this commit `14e7b5f60d8360eb84969ff08a1b77b365a5878e` should work.\n",
-    "You can do this quickly by installing it directly from master like so:\n"
+    "You can do this quickly by installing it directly from pip like so:\n"
    ]
   },
   {
@@ -36,7 +36,7 @@
    },
    "outputs": [],
    "source": [
-    "# pip install git+https://github.com/bmabey/pyLDAvis.git@master#egg=pyLDAvis"
+    "# pip install pyLDAvis
    ]
   },
   {


### PR DESCRIPTION
The latest stable version of pyLDAvis is of Jun 5, 2018. This should be sufficiently recent for lda2vec.